### PR TITLE
Update en_GB.po per official style guide

### DIFF
--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -57,8 +57,8 @@ msgstr "Input Device Settings..."
 
 #: ../plugins/volumealsabt/volumealsabt.c:1987
 #: ../plugins/volumealsabt/volumealsabt.c:2015
-msgid "Analog"
-msgstr "Analog"
+msgid "Analogue"
+msgstr "Analogue"
 
 #: ../plugins/volumealsabt/volumealsabt.c:1991
 #: ../plugins/volumealsabt/volumealsabt.c:2011


### PR DESCRIPTION
The official Raspberry Pi style guide - https://github.com/raspberrypilearning/style-guide/blob/master/style-guide.md - mandates the spelling of 'analogue' as 'analogue', not 'analog'. Correct en_GB translation file : analog -> analogue